### PR TITLE
LoginUserResponse에 sleepPk 추가 및 LoginResponse 변경

### DIFF
--- a/src/main/java/econo/app/sleeper/service/login/LoginService.java
+++ b/src/main/java/econo/app/sleeper/service/login/LoginService.java
@@ -26,18 +26,19 @@ public class LoginService {
         Optional<User> user = userRepository.findById(loginId);
 
         if (user.isEmpty()) {
-            return new LoginResponse("존재하지않는 회원입니다", null, null, null);
+            return new LoginResponse("존재하지않는 회원입니다", null, null);
         }
 
         if (!user.get().getUserPassword().equals(loginRequest.getUserPassword())) {
-            return new LoginResponse("비밀번호가 일치하지 않습니다.", null, null, null);
+            return new LoginResponse("비밀번호가 일치하지 않습니다.", null, null);
         }
         String userId = user.get().getUserId();
         Long userPk = user.get().getId();
 
         String newAccessToken = jwtTokenProvider.createAccessToken(userId);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
-        return new LoginResponse("access와 refresh토큰이 생성되었습니다", newAccessToken, newRefreshToken, userPk);
+
+        return new LoginResponse("로그인 되었습니다.",newAccessToken, newRefreshToken);
     }
     public Cookie logout(Cookie cookie) {
         cookie.setValue(null);

--- a/src/main/java/econo/app/sleeper/web/login/LoginResponse.java
+++ b/src/main/java/econo/app/sleeper/web/login/LoginResponse.java
@@ -1,6 +1,5 @@
 package econo.app.sleeper.web.login;
 
-import econo.app.sleeper.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,13 +14,12 @@ public class LoginResponse implements Serializable{
     private String message;
     private String accessToken;
     private String refreshToken;
-    private Long userPk;
-    public static LoginResponse of (String accessToken, String refreshToken, String message,Long userPk){
+
+    public static LoginResponse of (String message, String accessToken, String refreshToken){
         return LoginResponse.builder()
+                .message(message)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
-                .message(message)
-                .userPk(userPk)
                 .build();
     }
 

--- a/src/main/java/econo/app/sleeper/web/login/LoginUserResponse.java
+++ b/src/main/java/econo/app/sleeper/web/login/LoginUserResponse.java
@@ -1,0 +1,27 @@
+package econo.app.sleeper.web.login;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class LoginUserResponse implements Serializable{
+
+    private String message;
+    private Long sleepPk;
+    private Long userPk;
+    public static LoginUserResponse of (String message, Long sleepPk, Long userPk){
+        return LoginUserResponse.builder()
+                .sleepPk(sleepPk)
+                .message(message)
+                .userPk(userPk)
+                .build();
+    }
+
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
   datasource:
     url: jdbc:h2:tcp://localhost/~/sleeper
     username : sa
-    password :
+    password : sa
     driver-class-name : org.h2.Driver
 
   jpa:


### PR DESCRIPTION
기존에 프론트에 Token을 Response에 담아서 주는 LoginResponse를 Token과 메시지만 담아 LoginController로 넘겨주도록 하였고 LoginUserResponse에 sleelpPk와 userPk, 그리고 LoginResponse에서 받은 메시지를 UserController에서 담아서 반환하도록 만들었다.